### PR TITLE
🔧 Update build process to use references

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,26 @@ jobs:
 
       - uses: pre-commit/action@v1.0.1
 
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Read .nvmrc and pass it on
+        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
+        id: nvm
+
+      - name: Setup node w/ nvm version
+        uses: actions/setup-node@v1
+        with:
+          node-version: '${{ steps.nvm.outputs.NVMRC }}'
+
+      - name: yarn install w/ cache
+        uses: bahmutov/npm-install@v1
+
+      - name: Run tsc build
+        run: yarn build
+
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -74,9 +94,6 @@ jobs:
 
       - name: Install Packages
         run: yarn install --frozen-lockfile
-
-      - name: Test
-        run: yarn test
 
       - name: Authenticate with Registry
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ coverage/
 
 # output for tsc compile
 lib/
+*.tsbuildinfo

--- a/package.json
+++ b/package.json
@@ -4,11 +4,13 @@
   "scripts": {
     "test": "yarn lint && yarn lerna run test",
     "lint": "yarn eslint && yarn type",
-    "eslint": "eslint . --ext .js,.ts --max-warnings 0",
+    "eslint": "eslint . --ext .js,.ts --max-warnings 0 --report-unused-disable-directives",
     "type": "tsc --noEmit",
     "fmt": "pre-commit run --all-files && yarn eslint --fix",
     "build": "lerna run tsc",
-    "cleanBuilds": "find ./packages -type d -name lib -prune -exec rm -rf {} \\;",
+    "cleanbuilds": "yarn cleanBuilds:out && yarn cleanBuilds:buildinfo",
+    "cleanBuilds:out": "find ./packages -type d -name lib -prune -exec rm -rf {} \\;",
+    "cleanBuilds:buildinfo": "find ./packages -type f -name tsconfig.build.tsbuildinfo -prune -exec rm  {} \\;",
     "lerna:version": "lerna version --no-push",
     "lerna:publish": "lerna publish from-package"
   },

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -9,7 +9,7 @@
     "directory": "packages/blocks"
   },
   "scripts": {
-    "tsc": "tsc -p ./tsconfig.build.json",
+    "tsc": "tsc -b ./tsconfig.build.json",
     "test": "jest"
   },
   "author": "",

--- a/packages/blocks/tsconfig.build.json
+++ b/packages/blocks/tsconfig.build.json
@@ -1,4 +1,11 @@
 {
-  "extends": "./tsconfig.json",
-  "exclude": ["./**/*.spec.ts"]
+  "extends": "../../tsconfig.build.json",
+  "include": ["./src"],
+  "exclude": ["./**/*.spec.ts"],
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./lib",
+    "composite": true
+  },
+  "references": []
 }

--- a/packages/blocks/tsconfig.json
+++ b/packages/blocks/tsconfig.json
@@ -1,8 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./lib"
-  },
   "include": ["./src"]
 }

--- a/packages/bolt-interactions/package.json
+++ b/packages/bolt-interactions/package.json
@@ -4,7 +4,7 @@
   "description": "Easily create interaction patterns in bolt.",
   "main": "lib/index.js",
   "scripts": {
-    "tsc": "tsc -p ./tsconfig.build.json",
+    "tsc": "tsc -b ./tsconfig.build.json",
     "test": "NODE_ENV=test yarn jest"
   },
   "license": "Apache-2.0",

--- a/packages/bolt-interactions/tsconfig.build.json
+++ b/packages/bolt-interactions/tsconfig.build.json
@@ -1,4 +1,15 @@
 {
-  "extends": "./tsconfig.json",
-  "exclude": ["./**/*.spec.ts"]
+  "extends": "../../tsconfig.build.json",
+  "include": ["./src"],
+  "exclude": ["./**/*.spec.ts"],
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./lib",
+    "composite": true
+  },
+  "references": [
+    {
+      "path": "../jest-mock-web-client/tsconfig.build.json"
+    }
+  ]
 }

--- a/packages/bolt-interactions/tsconfig.json
+++ b/packages/bolt-interactions/tsconfig.json
@@ -1,8 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./lib"
-  },
   "include": ["./src"]
 }

--- a/packages/bolt-storage-file/package.json
+++ b/packages/bolt-storage-file/package.json
@@ -9,7 +9,7 @@
     "directory": "packages/bolt-storage-file"
   },
   "scripts": {
-    "tsc": "tsc -p ./tsconfig.build.json",
+    "tsc": "tsc -b ./tsconfig.build.json",
     "test": "NODE_ENV=test yarn jest"
   },
   "license": "Apache-2.0",

--- a/packages/bolt-storage-file/tsconfig.build.json
+++ b/packages/bolt-storage-file/tsconfig.build.json
@@ -1,4 +1,11 @@
 {
-  "extends": "./tsconfig.json",
-  "exclude": ["./**/*.spec.ts"]
+  "extends": "../../tsconfig.build.json",
+  "include": ["./src"],
+  "exclude": ["./**/*.spec.ts"],
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./lib",
+    "composite": true
+  },
+  "references": []
 }

--- a/packages/bolt-storage-file/tsconfig.json
+++ b/packages/bolt-storage-file/tsconfig.json
@@ -1,8 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./lib"
-  },
   "include": ["./src"]
 }

--- a/packages/fixtures/package.json
+++ b/packages/fixtures/package.json
@@ -9,7 +9,7 @@
     "directory": "packages/fixtures"
   },
   "scripts": {
-    "tsc": "tsc -p ./tsconfig.build.json",
+    "tsc": "tsc -b ./tsconfig.build.json",
     "test": "jest"
   },
   "license": "Apache-2.0",

--- a/packages/fixtures/src/index.ts
+++ b/packages/fixtures/src/index.ts
@@ -2,6 +2,4 @@ import * as events from './events';
 import fields from './fields';
 import ServerlessTester from './serverless-tester';
 
-// Plans to add more fixtures like `web` for responses
-// eslint-disable-next-line import/prefer-default-export
 export { events, fields, ServerlessTester };

--- a/packages/fixtures/tsconfig.build.json
+++ b/packages/fixtures/tsconfig.build.json
@@ -1,4 +1,11 @@
 {
-  "extends": "./tsconfig.json",
-  "exclude": ["./**/*.spec.ts"]
+  "extends": "../../tsconfig.build.json",
+  "include": ["./src"],
+  "exclude": ["./**/*.spec.ts"],
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./lib",
+    "composite": true
+  },
+  "references": []
 }

--- a/packages/fixtures/tsconfig.json
+++ b/packages/fixtures/tsconfig.json
@@ -1,8 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./lib"
-  },
   "include": ["./src"]
 }

--- a/packages/jest-bolt-receiver/package.json
+++ b/packages/jest-bolt-receiver/package.json
@@ -9,7 +9,7 @@
     "directory": "packages/jest-bolt-receiver"
   },
   "scripts": {
-    "tsc": "tsc -p ./tsconfig.build.json",
+    "tsc": "tsc -b ./tsconfig.build.json",
     "test": "jest"
   },
   "license": "Apache-2.0",

--- a/packages/jest-bolt-receiver/tsconfig.build.json
+++ b/packages/jest-bolt-receiver/tsconfig.build.json
@@ -1,4 +1,18 @@
 {
-  "extends": "./tsconfig.json",
-  "exclude": ["./**/*.spec.ts"]
+  "extends": "../../tsconfig.build.json",
+  "include": ["./src"],
+  "exclude": ["./**/*.spec.ts"],
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./lib",
+    "composite": true
+  },
+  "references": [
+    {
+      "path": "../jest-mock-web-client/tsconfig.build.json"
+    },
+    {
+      "path": "../fixtures/tsconfig.build.json"
+    }
+  ]
 }

--- a/packages/jest-bolt-receiver/tsconfig.json
+++ b/packages/jest-bolt-receiver/tsconfig.json
@@ -1,8 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./lib"
-  },
   "include": ["./src"]
 }

--- a/packages/jest-mock-web-client/package.json
+++ b/packages/jest-mock-web-client/package.json
@@ -9,7 +9,7 @@
     "directory": "packages/jest-mock-web-client"
   },
   "scripts": {
-    "tsc": "tsc -p ./tsconfig.build.json",
+    "tsc": "tsc -b ./tsconfig.build.json",
     "test": "jest"
   },
   "license": "Apache-2.0",

--- a/packages/jest-mock-web-client/tsconfig.build.json
+++ b/packages/jest-mock-web-client/tsconfig.build.json
@@ -1,4 +1,11 @@
 {
-  "extends": "./tsconfig.json",
-  "exclude": ["./**/*.spec.ts"]
+  "extends": "../../tsconfig.build.json",
+  "include": ["./src"],
+  "exclude": ["./**/*.spec.ts"],
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./lib",
+    "composite": true
+  },
+  "references": []
 }

--- a/packages/jest-mock-web-client/tsconfig.json
+++ b/packages/jest-mock-web-client/tsconfig.json
@@ -1,8 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./lib"
-  },
   "include": ["./src"]
 }

--- a/packages/koa-bolt/package.json
+++ b/packages/koa-bolt/package.json
@@ -9,7 +9,7 @@
     "directory": "packages/bolt-koa"
   },
   "scripts": {
-    "tsc": "tsc -p ./tsconfig.build.json",
+    "tsc": "tsc -b ./tsconfig.build.json",
     "test": "NODE_ENV=test yarn jest"
   },
   "license": "Apache-2.0",

--- a/packages/koa-bolt/tsconfig.build.json
+++ b/packages/koa-bolt/tsconfig.build.json
@@ -1,4 +1,11 @@
 {
-  "extends": "./tsconfig.json",
-  "exclude": ["./**/*.spec.ts"]
+  "extends": "../../tsconfig.build.json",
+  "include": ["./src"],
+  "exclude": ["./**/*.spec.ts"],
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./lib",
+    "composite": true
+  },
+  "references": []
 }

--- a/packages/koa-bolt/tsconfig.json
+++ b/packages/koa-bolt/tsconfig.json
@@ -1,8 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./lib"
-  },
   "include": ["./src"]
 }

--- a/packages/slackctl/tsconfig.json
+++ b/packages/slackctl/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "rootDir": "src"
-  }
+    "rootDir": "src",
+    "composite": true
+  },
+  "references": []
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -9,7 +9,6 @@
     "strict": true,
     "preserveSymlinks": true,
     "allowJs": true,
-    "noLib": false,
     "sourceMap": true,
     "removeComments": true,
     "emitDecoratorMetadata": true,

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "moduleResolution": "node",
+    "noImplicitAny": true,
+    "strict": true,
+    "preserveSymlinks": true,
+    "allowJs": true,
+    "noLib": false,
+    "sourceMap": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true
+  },
+  "exclude": ["node_modules", "**/coverage", "**/lib"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,23 +1,9 @@
 {
+  "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "declaration": true,
-    "module": "commonjs",
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "moduleResolution": "node",
-    "noImplicitAny": true,
-    "strict": true,
-    "preserveSymlinks": true,
-    "allowJs": true,
-    "noLib": false,
-    "sourceMap": true,
-    "removeComments": true,
-    "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
     "paths": {
       "@slack-wrench/*": ["packages/*/src"]
     }
-  },
-  "exclude": ["node_modules", "**/coverage", "**/lib"]
+  }
 }


### PR DESCRIPTION
**Related Issue**  
Supports #42 

**Related PRs**  
This PR is not dependent on any other PR

**What does this PR do?**  
Fixes the broken tsc compiler so we can release things. 

**Description of Changes**  
1. Added a build stage so we catch this at merge time later
2. Added `references` to project tsconfigs. Interestingly, you can't have references _and_ paths play nicely together, so, well, you'll see. 
3. Boyscouting, added `--report-unused-disable-directives` to eslint and fixed the one error.

Inspiration and description in implementation: https://medium.com/@NiGhTTraX/how-to-set-up-a-typescript-monorepo-with-lerna-c6acda7d4559

Future implementation: https://github.com/microsoft/TypeScript/issues/25376

**What gif most accurately describes how I feel towards this PR?**  

![](https://media2.giphy.com/media/ymkGhUXrj32uY/giphy.gif?cid=5a38a5a2372be9c16cf35dd48c70eb6ee867d013aa3689da&rid=giphy.gif)

