### PR TITLE
🔩 Handle view submit in bolt interactions + fixture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ coverage/
 
 .npmrc
 
+.DS_Store
 
 # output for tsc compile
 lib/

--- a/packages/bolt-interactions/README.md
+++ b/packages/bolt-interactions/README.md
@@ -175,6 +175,46 @@ interactionFlow<FlowState>((flow, app) => {
 
 Create a [flow listener](#flow-listener) that listens for [actions](https://slack.dev/bolt/concepts#action-listening)
 
+### flow.view
+
+In handling views, you'll need to pass an interactionId as the callback and reference the same string in a `flow.view` action handler. An example of handling view submissions with a view that is opened when an overflow action is clicked:
+
+```typescript
+interactionFlow<FlowState>((flow, app) => {
+  const callback_id = 'edit';
+
+  flow.action<BlockOverflowAction>(
+    'openEdit',
+    async ({
+      action: { action_id },
+      body: { trigger_id },
+      context: { token, interactionIds },
+    }) => {
+      await flow.client.views.open({
+        trigger_id,
+        token,
+        view: {
+          type: 'modal',
+          // setup callback_id with unique interactionId based on string
+          callback_id: interactionIds[callback_id],
+          title: PlainText('Edit Story'),
+          submit: PlainText('Update Story'),
+          close: PlainText('Cancel'),
+          blocks: [
+            /* ... */
+          ],
+        },
+      });
+    },
+  );
+
+  // handle all submissions of above; callback_id is used to recapture context
+  flow.view<ViewSubmitAction>(callback_id, async ({ view, context, ... }) => {
+    /* do things when a SlackViewAction is triggered */
+  });
+});
+```
+
 ## Working with Ids
 
 If you are working with your own ids for flow instances, it can be helpful to parse them. There some utilities to help with that.

--- a/packages/bolt-interactions/package.json
+++ b/packages/bolt-interactions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack-wrench/bolt-interactions",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Easily create interaction patterns in bolt.",
   "main": "lib/index.js",
   "scripts": {
@@ -18,7 +18,7 @@
     "@slack/bolt": ">=1.0.0 <3.0.0"
   },
   "devDependencies": {
-    "@slack-wrench/fixtures": "^2.0.0",
+    "@slack-wrench/fixtures": "^2.2.0",
     "@slack-wrench/jest-bolt-receiver": "^2.0.0",
     "@slack-wrench/jest-mock-web-client": "^1.1.0",
     "@slack/bolt": "^1.4.1",

--- a/packages/bolt-interactions/src/interaction-flow.spec.ts
+++ b/packages/bolt-interactions/src/interaction-flow.spec.ts
@@ -1,4 +1,4 @@
-import { actions, slashCommand } from '@slack-wrench/fixtures';
+import { actions, slashCommand, view } from '@slack-wrench/fixtures';
 import JestReceiver from '@slack-wrench/jest-bolt-receiver';
 import { App, ConversationStore, MemoryStore } from '@slack/bolt';
 import delay from 'delay';
@@ -126,6 +126,29 @@ describe('Bolt interaction flows', () => {
       const { ack } = receiver.send(
         actions.blockButtonAction({
           action_id,
+        }),
+      );
+
+      await delay(0);
+      expect(ack).toBeCalled();
+    });
+
+    it('sets the previous state for stateful view actions', async () => {
+      expect.assertions(2);
+
+      const id = 'test';
+      const callback_id = InteractionFlow.createInteractionId(flowId, id);
+
+      interactionFlow(flowName, flow => {
+        flow.view(id, ({ context, ack }) => {
+          expect(context.state).toEqual(state);
+          ack();
+        });
+      })(app);
+
+      const { ack } = receiver.send(
+        view.viewSubmitAction({
+          callback_id,
         }),
       );
 

--- a/packages/bolt-interactions/src/interaction-flow.ts
+++ b/packages/bolt-interactions/src/interaction-flow.ts
@@ -6,6 +6,7 @@ import {
   MemoryStore,
   Middleware,
   SlackAction,
+  SlackViewAction,
 } from '@slack/bolt';
 import { WebClient } from '@slack/web-api';
 import uuid from 'uuid/v4';
@@ -112,6 +113,15 @@ export class InteractionFlow<FlowState = unknown> {
       return flowId;
     }
 
+    /* istanbul ignore else */
+    if ('view' in body) {
+      const { flowId } = InteractionFlow.parseInteractionId(
+        body.view.callback_id,
+      );
+
+      return flowId;
+    }
+
     // Just in case slack does something weird, I'm unsure how to trigger this
     /* istanbul ignore next */
     throw new Error("Couldn't find a flow in provided context");
@@ -201,6 +211,20 @@ export class InteractionFlow<FlowState = unknown> {
     this.interactionIds.push(constraints.action_id);
 
     this.app.action(flowConstraints, ...this.injectListeners(...listeners));
+  }
+
+  view<ViewActionType extends SlackViewAction>(
+    callback_id: string,
+    ...listeners: Middleware<
+      Interaction.FlowViewMiddlewareArgs<FlowState, ViewActionType>
+    >[]
+  ): void {
+    this.interactionIds.push(callback_id);
+
+    this.app.view(
+      this.interactionIdPattern(callback_id),
+      ...this.injectListeners(...listeners),
+    );
   }
 }
 

--- a/packages/bolt-interactions/src/types/interaction.ts
+++ b/packages/bolt-interactions/src/types/interaction.ts
@@ -1,4 +1,10 @@
-import { App, SlackAction, SlackActionMiddlewareArgs } from '@slack/bolt';
+import {
+  App,
+  SlackAction,
+  SlackActionMiddlewareArgs,
+  SlackViewAction,
+  SlackViewMiddlewareArgs,
+} from '@slack/bolt';
 
 import { InteractionFlow } from '../interaction-flow';
 
@@ -25,6 +31,13 @@ export interface FlowActionMiddlewareArgs<
 >
   extends FlowMiddlewareArgs<FlowState>,
     SlackActionMiddlewareArgs<ActionType> {}
+
+export interface FlowViewMiddlewareArgs<
+  FlowState,
+  ViewActionType extends SlackViewAction = SlackViewAction
+>
+  extends FlowMiddlewareArgs<FlowState>,
+    SlackViewMiddlewareArgs<ViewActionType> {}
 
 export interface ActionConstraints {
   action_id: string;

--- a/packages/fixtures/README.md
+++ b/packages/fixtures/README.md
@@ -9,6 +9,7 @@ This package contains type-safe fixtures and application wrappers for testing sl
   - [Slash Commands](#slash-commands)
   - [Actions](#actions)
     - [Block Button Action](#block-button-action)
+    - [View Submit Action](#view-submit-action)
 - [Global Fields](#global-fields)
   - [Overriding](#overriding)
 - [Serverless Tester](#serverless-tester)
@@ -107,6 +108,26 @@ Arguments:
 
 Returns:
 Object containing a block action event
+
+#### View Submit Action
+
+```typescript
+view.viewSubmitAction(
+  view?: Partial<ViewOutput>,
+  options?: Partial<BlockButtonAction>,
+)
+// : ViewSubmitAction => { type: 'view_submission', view: { id: 'editView', state: {}, ...} ], user, ... }
+```
+
+Creates an event from a view submit action.
+
+Arguments:
+
+- `view`: Overrides to [ViewOutput](https://github.com/slackapi/bolt/blob/master/src/types/view/index.ts#L73) values, on `ViewSubmitAction.view`
+- `options`: Any fields to override on the default [ViewSubmitAction event](https://github.com/slackapi/bolt/blob/master/src/types/view/index.ts#L31)
+
+Returns:
+Object containing a view submit action event
 
 ## Global Fields
 

--- a/packages/fixtures/package.json
+++ b/packages/fixtures/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack-wrench/fixtures",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Slack api fixtures for testing",
   "main": "lib/index.js",
   "repository": {

--- a/packages/fixtures/src/index.ts
+++ b/packages/fixtures/src/index.ts
@@ -3,5 +3,6 @@ import * as events from './events';
 import fields from './fields';
 import ServerlessTester from './serverless-tester';
 import slashCommand from './slashCommand';
+import * as view from './view';
 
-export { actions, events, fields, ServerlessTester, slashCommand };
+export { actions, events, view, fields, ServerlessTester, slashCommand };

--- a/packages/fixtures/src/view.spec.ts
+++ b/packages/fixtures/src/view.spec.ts
@@ -1,0 +1,30 @@
+import { view } from './index';
+
+describe('Views fixtures', () => {
+  const user_id = 'UPINKIE';
+  const options = {
+    user: {
+      id: user_id,
+      name: 'Pinkie',
+    },
+  };
+
+  Object.entries({
+    submit: view.viewSubmitAction,
+  }).forEach(([name, viewAction]) => {
+    it(`generates view ${name} action with overrideable view`, () => {
+      expect.assertions(1);
+      const id = name;
+      const event = viewAction({ id });
+
+      // Not including more in depth tests as typing should serve that purpose
+      expect(event.view.id).toEqual(id);
+    });
+
+    it(`can override view ${name} action fields`, () => {
+      expect.assertions(1);
+
+      expect(viewAction({}, options)).toEqual(expect.objectContaining(options));
+    });
+  });
+});

--- a/packages/fixtures/src/view.ts
+++ b/packages/fixtures/src/view.ts
@@ -1,0 +1,41 @@
+import { ViewSubmitAction } from '@slack/bolt';
+
+import fields from './fields';
+
+// eslint-disable-next-line import/prefer-default-export
+export function viewSubmitAction(
+  view?: Partial<ViewSubmitAction['view']>,
+  options?: Partial<ViewSubmitAction>,
+): ViewSubmitAction {
+  const { api_app_id, callback_id, team, token, user } = fields;
+
+  return {
+    type: 'view_submission',
+    team,
+    user,
+    view: {
+      id: '',
+      team_id: team.id,
+      app_id: api_app_id,
+      callback_id,
+      bot_id: '',
+      // can't use PlainText because weird bolt typings: https://github.com/slackapi/bolt/blob/master/src/types/view/index.ts#L20
+      title: { type: 'plain_text', text: '', emoji: false },
+      type: '',
+      blocks: [],
+      close: null,
+      submit: null,
+      hash: '',
+      root_view_id: null,
+      previous_view_id: null,
+      clear_on_close: false,
+      notify_on_close: false,
+      private_metadata: '',
+      state: { values: {} },
+      ...view,
+    },
+    api_app_id,
+    token,
+    ...options,
+  };
+}


### PR DESCRIPTION
**Related PRs**  
This PR is not dependent on any other PR

**What does this PR do?**  
- Enables handling view actions with bolt-interactions
- adds `flow.view` functionality
- adds fixture for viewSubmitAction

**Description of Changes**  
Because views don't have an `action_id`, we have to use the `callback_id`. This code sets up typing and a `flow.view` function for handling view submission while maintaining state.

**What gif most accurately describes how I feel towards this PR?**  


![](https://media1.giphy.com/media/f9k1tV7HyORcngKF8v/giphy.gif?cid=5a38a5a2d691d9393c3c9bb2821c78569271b295da09404d&rid=giphy.gif)
