### PR TITLE
add memberJoinedChannel event

### DIFF
--- a/packages/fixtures/package.json
+++ b/packages/fixtures/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack-wrench/fixtures",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Slack api fixtures for testing",
   "main": "lib/index.js",
   "repository": {

--- a/packages/fixtures/src/__snapshots__/events.spec.ts.snap
+++ b/packages/fixtures/src/__snapshots__/events.spec.ts.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Events fixtures generates a memberJoinedChannel block 1`] = `
+Object {
+  "api_app_id": "API_APP_ID",
+  "authed_users": Array [
+    "UUSERID",
+  ],
+  "event": Object {
+    "channel": "CCHANNELID",
+    "channel_type": "C",
+    "inviter": "IINVITERID",
+    "team": "TTEAMID",
+    "type": "member_joined_channel",
+    "user": "UUSERID",
+  },
+  "event_id": "EVENT_ID",
+  "event_time": 1234567890,
+  "team_id": "TTEAMID",
+  "token": "TOKEN",
+  "type": "event_callback",
+}
+`;

--- a/packages/fixtures/src/__snapshots__/fields.spec.ts.snap
+++ b/packages/fixtures/src/__snapshots__/fields.spec.ts.snap
@@ -13,7 +13,6 @@ Fields {
   "channel": Object {
     "id": "CCHANNELID",
     "name": "channel",
-    "type": "C",
   },
   "event_id": "EVENT_ID",
   "event_time": 1234567890,

--- a/packages/fixtures/src/__snapshots__/fields.spec.ts.snap
+++ b/packages/fixtures/src/__snapshots__/fields.spec.ts.snap
@@ -13,9 +13,14 @@ Fields {
   "channel": Object {
     "id": "CCHANNELID",
     "name": "channel",
+    "type": "C",
   },
   "event_id": "EVENT_ID",
   "event_time": 1234567890,
+  "inviter": Object {
+    "id": "IINVITERID",
+    "name": "INVITER",
+  },
   "response_url": "https://fake.slack/response_url",
   "team": Object {
     "domain": "team-domain",

--- a/packages/fixtures/src/events.spec.ts
+++ b/packages/fixtures/src/events.spec.ts
@@ -49,9 +49,9 @@ describe('Events fixtures', () => {
     expect.assertions(1);
 
     // Not including more in depth tests as typing should serve that purpose
-    expect(events.memberJoinedChannel(user_id, channel, channel_type, team).event).toEqual(
-      expect.objectContaining({ type: 'member_joined_channel' }),
-    );
+    expect(
+      events.memberJoinedChannel(user_id, channel, channel_type, team).event,
+    ).toEqual(expect.objectContaining({ type: 'member_joined_channel' }));
   });
 
   it('can override memberJoinedChannel fields', () => {
@@ -59,8 +59,9 @@ describe('Events fixtures', () => {
 
     const options = { user: 'NEW_USER' };
 
-    expect(events.memberJoinedChannel(user_id, channel, channel_type, team, options).event).toEqual(
-      expect.objectContaining(options),
-    );
+    expect(
+      events.memberJoinedChannel(user_id, channel, channel_type, team, options)
+        .event,
+    ).toEqual(expect.objectContaining(options));
   });
 });

--- a/packages/fixtures/src/events.spec.ts
+++ b/packages/fixtures/src/events.spec.ts
@@ -45,9 +45,7 @@ describe('Events fixtures', () => {
   it('generates a memberJoinedChannel block', () => {
     expect.assertions(1);
 
-    expect(events.memberJoinedChannel().event).toEqual(
-      expect.objectContaining({ type: 'member_joined_channel' }),
-    );
+    expect(events.memberJoinedChannel()).toMatchSnapshot();
   });
 
   it('can override memberJoinedChannel fields', () => {
@@ -64,7 +62,7 @@ describe('Events fixtures', () => {
     );
   });
 
-  it('channel type is infered in memberJoinedChannel event', () => {
+  it('channel type is inferred in memberJoinedChannel event', () => {
     expect.assertions(1);
 
     const options = { channel: 'GNEW_CHANNEL' };

--- a/packages/fixtures/src/events.spec.ts
+++ b/packages/fixtures/src/events.spec.ts
@@ -45,29 +45,32 @@ describe('Events fixtures', () => {
   it('generates a memberJoinedChannel block', () => {
     expect.assertions(1);
 
-    expect(
-      events.memberJoinedChannel().event,
-    ).toEqual(expect.objectContaining({ type: 'member_joined_channel' }));
+    expect(events.memberJoinedChannel().event).toEqual(
+      expect.objectContaining({ type: 'member_joined_channel' }),
+    );
   });
 
   it('can override memberJoinedChannel fields', () => {
     expect.assertions(1);
 
-    const options = { user: 'UNEW_USER', channel: 'CNEW_CHANNEL', team: 'TNEW_TEAM', channel_type: 'G' };
-    expect(
-      events.memberJoinedChannel(options)
-        .event,
-    ).toEqual(expect.objectContaining(options));
+    const options = {
+      user: 'UNEW_USER',
+      channel: 'CNEW_CHANNEL',
+      team: 'TNEW_TEAM',
+      channel_type: 'G',
+    };
+    expect(events.memberJoinedChannel(options).event).toEqual(
+      expect.objectContaining(options),
+    );
   });
 
   it('channel type is infered in memberJoinedChannel event', () => {
     expect.assertions(1);
 
     const options = { channel: 'GNEW_CHANNEL' };
-    const result = { channel_type: 'G' }
-    expect(
-      events.memberJoinedChannel(options)
-        .event,
-    ).toEqual(expect.objectContaining(result));
+    const result = { channel_type: 'G' };
+    expect(events.memberJoinedChannel(options).event).toEqual(
+      expect.objectContaining(result),
+    );
   });
 });

--- a/packages/fixtures/src/events.spec.ts
+++ b/packages/fixtures/src/events.spec.ts
@@ -3,6 +3,9 @@ import { events } from './index';
 describe('Events fixtures', () => {
   const user_id = 'UPINKIE';
   const text = 'Rainbow is 20% cooler';
+  const channel = 'CCHANNELID';
+  const channel_type = 'C';
+  const team = 'TTEAMID';
 
   it('generates a message block', () => {
     expect.assertions(1);
@@ -38,6 +41,25 @@ describe('Events fixtures', () => {
     const options = { user: user_id };
 
     expect(events.appMention(text, options).event).toEqual(
+      expect.objectContaining(options),
+    );
+  });
+
+  it('generates a memberJoinedChannel block', () => {
+    expect.assertions(1);
+
+    // Not including more in depth tests as typing should serve that purpose
+    expect(events.memberJoinedChannel(user_id, channel, channel_type, team).event).toEqual(
+      expect.objectContaining({ type: 'member_joined_channel' }),
+    );
+  });
+
+  it('can override memberJoinedChannel fields', () => {
+    expect.assertions(1);
+
+    const options = { user: 'NEW_USER' };
+
+    expect(events.memberJoinedChannel(user_id, channel, channel_type, team, options).event).toEqual(
       expect.objectContaining(options),
     );
   });

--- a/packages/fixtures/src/events.spec.ts
+++ b/packages/fixtures/src/events.spec.ts
@@ -3,9 +3,6 @@ import { events } from './index';
 describe('Events fixtures', () => {
   const user_id = 'UPINKIE';
   const text = 'Rainbow is 20% cooler';
-  const channel = 'CCHANNELID';
-  const channel_type = 'C';
-  const team = 'TTEAMID';
 
   it('generates a message block', () => {
     expect.assertions(1);
@@ -48,20 +45,29 @@ describe('Events fixtures', () => {
   it('generates a memberJoinedChannel block', () => {
     expect.assertions(1);
 
-    // Not including more in depth tests as typing should serve that purpose
     expect(
-      events.memberJoinedChannel(user_id, channel, channel_type, team).event,
+      events.memberJoinedChannel().event,
     ).toEqual(expect.objectContaining({ type: 'member_joined_channel' }));
   });
 
   it('can override memberJoinedChannel fields', () => {
     expect.assertions(1);
 
-    const options = { user: 'NEW_USER' };
-
+    const options = { user: 'UNEW_USER', channel: 'CNEW_CHANNEL', team: 'TNEW_TEAM', channel_type: 'G' };
     expect(
-      events.memberJoinedChannel(user_id, channel, channel_type, team, options)
+      events.memberJoinedChannel(options)
         .event,
     ).toEqual(expect.objectContaining(options));
+  });
+
+  it('channel type is infered in memberJoinedChannel event', () => {
+    expect.assertions(1);
+
+    const options = { channel: 'GNEW_CHANNEL' };
+    const result = { channel_type: 'G' }
+    expect(
+      events.memberJoinedChannel(options)
+        .event,
+    ).toEqual(expect.objectContaining(result));
   });
 });

--- a/packages/fixtures/src/events.ts
+++ b/packages/fixtures/src/events.ts
@@ -101,7 +101,7 @@ export const memberJoinedChannel = (
     ? options.channel.charAt(0)
     : channel.charAt(0);
 
-  return apiEvent<MemberJoinedChannelEvent>({
+  return apiEvent({
     type: 'member_joined_channel',
     user,
     channel,

--- a/packages/fixtures/src/events.ts
+++ b/packages/fixtures/src/events.ts
@@ -90,9 +90,16 @@ export const appMention = (
 export const memberJoinedChannel = (
   options: Partial<MemberJoinedChannelEvent> = {},
 ): EnvelopedEvent<MemberJoinedChannelEvent> => {
-  const { channel: {id: channel},  inviter: {id: inviter}, team: {id: team}, user: {id: user} } = fields;
- 
-  const channel_type = options.channel? options.channel.charAt(0) : channel.charAt(0);
+  const {
+    channel: { id: channel },
+    inviter: { id: inviter },
+    team: { id: team },
+    user: { id: user },
+  } = fields;
+
+  const channel_type = options.channel
+    ? options.channel.charAt(0)
+    : channel.charAt(0);
 
   return apiEvent<MemberJoinedChannelEvent>({
     type: 'member_joined_channel',

--- a/packages/fixtures/src/events.ts
+++ b/packages/fixtures/src/events.ts
@@ -88,13 +88,11 @@ export const appMention = (
 };
 
 export const memberJoinedChannel = (
-  user: string,
-  channel: string,
-  channel_type: string,
-  team: string,
   options: Partial<MemberJoinedChannelEvent> = {},
 ): EnvelopedEvent<MemberJoinedChannelEvent> => {
-  const { inviter } = fields;
+  const { channel: {id: channel},  inviter: {id: inviter}, team: {id: team}, user: {id: user} } = fields;
+ 
+  const channel_type = options.channel? options.channel.charAt(0) : channel.charAt(0);
 
   return apiEvent<MemberJoinedChannelEvent>({
     type: 'member_joined_channel',
@@ -102,7 +100,7 @@ export const memberJoinedChannel = (
     channel,
     channel_type,
     team,
-    inviter: inviter.id,
+    inviter,
     ...options,
   });
 };

--- a/packages/fixtures/src/events.ts
+++ b/packages/fixtures/src/events.ts
@@ -1,7 +1,7 @@
 /**
  * For all events that arrive via event's api subscription
  */
-import { AppMentionEvent, BasicSlackEvent, MessageEvent } from '@slack/bolt';
+import { AppMentionEvent, BasicSlackEvent, MemberJoinedChannelEvent, MessageEvent } from '@slack/bolt';
 
 import fields from './fields';
 
@@ -78,6 +78,26 @@ export const appMention = (
     event_ts: ts,
     channel: channel.id,
     user: user.id,
+    ...options,
+  });
+};
+
+export const memberJoinedChannel = (
+  user: string,
+  channel: string,
+  channel_type: string,
+  team: string,
+  options: Partial<MemberJoinedChannelEvent> = {},
+): EnvelopedEvent<MemberJoinedChannelEvent> => {
+  const { inviter } = fields;
+
+  return apiEvent<MemberJoinedChannelEvent>({
+    type: 'member_joined_channel',
+    user,
+    channel,
+    channel_type,
+    team,
+    inviter: inviter.id,
     ...options,
   });
 };

--- a/packages/fixtures/src/events.ts
+++ b/packages/fixtures/src/events.ts
@@ -1,7 +1,12 @@
 /**
  * For all events that arrive via event's api subscription
  */
-import { AppMentionEvent, BasicSlackEvent, MemberJoinedChannelEvent, MessageEvent } from '@slack/bolt';
+import {
+  AppMentionEvent,
+  BasicSlackEvent,
+  MemberJoinedChannelEvent,
+  MessageEvent,
+} from '@slack/bolt';
 
 import fields from './fields';
 

--- a/packages/fixtures/src/fields.ts
+++ b/packages/fixtures/src/fields.ts
@@ -57,7 +57,7 @@ class Fields {
     this.channel = {
       id: 'CCHANNELID',
       name: 'channel',
-      type: 'C'
+      type: 'C',
     };
     this.team = {
       id: 'TTEAMID',

--- a/packages/fixtures/src/fields.ts
+++ b/packages/fixtures/src/fields.ts
@@ -13,7 +13,7 @@ class Fields {
 
   public user!: { name: string; id: string };
 
-  public channel!: { name: string; id: string; };
+  public channel!: { name: string; id: string };
 
   public team!: {
     domain: string;

--- a/packages/fixtures/src/fields.ts
+++ b/packages/fixtures/src/fields.ts
@@ -13,12 +13,14 @@ class Fields {
 
   public user!: { name: string; id: string };
 
-  public channel!: { name: string; id: string };
+  public channel!: { name: string; id: string; type: string };
 
   public team!: {
     domain: string;
     id: string;
   };
+
+  public inviter!: { name: string; id: string };
 
   public ts!: string;
 
@@ -55,10 +57,15 @@ class Fields {
     this.channel = {
       id: 'CCHANNELID',
       name: 'channel',
+      type: 'C'
     };
     this.team = {
       id: 'TTEAMID',
       domain: 'team-domain',
+    };
+    this.inviter = {
+      id: 'IINVITERID',
+      name: 'INVITER',
     };
     this.ts = ts;
     this.event_time = 1234567890;

--- a/packages/fixtures/src/fields.ts
+++ b/packages/fixtures/src/fields.ts
@@ -13,7 +13,7 @@ class Fields {
 
   public user!: { name: string; id: string };
 
-  public channel!: { name: string; id: string; type: string };
+  public channel!: { name: string; id: string; };
 
   public team!: {
     domain: string;
@@ -57,7 +57,6 @@ class Fields {
     this.channel = {
       id: 'CCHANNELID',
       name: 'channel',
-      type: 'C',
     };
     this.team = {
       id: 'TTEAMID',


### PR DESCRIPTION
**Related PRs**  
This PR is not dependent on any other PR

**What does this PR do?**  
Adds member_joined_channel event: https://api.slack.com/events/member_joined_channel
 
**Description of Changes**  
Small changes to fields to add inviter. user, channel and team are required for new event.
