### PR TITLE
Element limits

### DIFF
--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -193,6 +193,6 @@ OptionObject(dynamicText, 'value', undefined, {
 });
 ```
 
-Transform function signature: `<T>(limit: number, value: T) => T`. Be sure to return an value that is the same type the `value` passed - text element, string, option object array, etc. depending on the field.
+Transform function signature: `<T>(limit: number, value: T) => T`. Be sure to retur an value that is the same type the `value` passed - text element, string, option object array, etc. depending on the field.
 
-Note that this function only gets called when the passed dynamicText is greater than the limit. Also, if you end up returning a string longer than `limit`, the block could break when the API call is made to Slack (since Slack will refuse the request).
+Note that this function only gets called when the passed dynamicText is greater than the limit. Also, if you end up returning a value under the `limit`, the block could break when the API call is made to Slack (since Slack will refuse the request).

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -193,6 +193,6 @@ OptionObject(dynamicText, 'value', undefined, {
 });
 ```
 
-Transform function signature: `<T>(limit: number, value: T) => T`. Be sure to retur an value that is the same type the `value` passed - text element, string, option object array, etc. depending on the field.
+Transform function signature: `<T>(limit: number, value: T) => T`. Be sure to return a value that is the same type as the `value` passed - text element, string, option object array, etc. depending on the field.
 
 Note that this function only gets called when the passed dynamicText is greater than the limit. Also, if you end up returning a value under the `limit`, the block could break when the API call is made to Slack (since Slack will refuse the request).

--- a/packages/blocks/src/__snapshots__/elements.spec.ts.snap
+++ b/packages/blocks/src/__snapshots__/elements.spec.ts.snap
@@ -1,5 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Slack Element widgets button renders 1`] = `
+Object {
+  "action_id": "ravenAgree",
+  "text": Object {
+    "emoji": true,
+    "text": "Ravenclaw is obviously the best house.",
+    "type": "plain_text",
+  },
+  "type": "button",
+}
+`;
+
 exports[`Slack Element widgets checkbox input element renders a minimal example 1`] = `
 Object {
   "action_id": "title",
@@ -125,6 +137,14 @@ Object {
     },
   ],
   "type": "checkboxes",
+}
+`;
+
+exports[`Slack Element widgets image renders 1`] = `
+Object {
+  "alt_text": "Ravenclaw is obviously the best house.",
+  "image_url": "http://placekitten.com/700/500",
+  "type": "image",
 }
 `;
 
@@ -257,6 +277,60 @@ Object {
 }
 `;
 
+exports[`Slack Element widgets overflow menu renders 1`] = `
+Object {
+  "action_id": "house-actions",
+  "options": Array [
+    Object {
+      "text": Object {
+        "emoji": true,
+        "text": "Why best?",
+        "type": "plain_text",
+      },
+      "value": "why-best-raven",
+    },
+    Object {
+      "text": Object {
+        "emoji": true,
+        "text": "Ping JK",
+        "type": "plain_text",
+      },
+      "value": "notify-author",
+    },
+  ],
+  "type": "overflow",
+}
+`;
+
+exports[`Slack Element widgets plaintext input renders minimally 1`] = `
+Object {
+  "action_id": "title",
+  "initial_value": "and the Prisoner of Azkaban",
+  "placeholder": Object {
+    "emoji": true,
+    "text": "Enter a title",
+    "type": "plain_text",
+  },
+  "type": "plain_text_input",
+}
+`;
+
+exports[`Slack Element widgets plaintext input renders with initial value, placeholder, and opts 1`] = `
+Object {
+  "action_id": "title",
+  "initial_value": "and the Prisoner of Azkaban",
+  "max_length": 200,
+  "min_length": 10,
+  "multiline": true,
+  "placeholder": Object {
+    "emoji": true,
+    "text": "Enter a title",
+    "type": "plain_text",
+  },
+  "type": "plain_text_input",
+}
+`;
+
 exports[`Slack Element widgets radio input element renders a minimal example 1`] = `
 Object {
   "action_id": "title",
@@ -370,80 +444,6 @@ Object {
     },
   ],
   "type": "radio_buttons",
-}
-`;
-
-exports[`Slack Element widgets renders a button element 1`] = `
-Object {
-  "action_id": "ravenAgree",
-  "text": Object {
-    "emoji": true,
-    "text": "Ravenclaw is obviously the best house.",
-    "type": "plain_text",
-  },
-  "type": "button",
-}
-`;
-
-exports[`Slack Element widgets renders a minimal plain-text input element 1`] = `
-Object {
-  "action_id": "title",
-  "initial_value": "and the Prisoner of Azkaban",
-  "placeholder": Object {
-    "emoji": true,
-    "text": "Enter a title",
-    "type": "plain_text",
-  },
-  "type": "plain_text_input",
-}
-`;
-
-exports[`Slack Element widgets renders a plain-text input element with initial value, placeholder, and opts 1`] = `
-Object {
-  "action_id": "title",
-  "initial_value": "and the Prisoner of Azkaban",
-  "max_length": 200,
-  "min_length": 10,
-  "multiline": true,
-  "placeholder": Object {
-    "emoji": true,
-    "text": "Enter a title",
-    "type": "plain_text",
-  },
-  "type": "plain_text_input",
-}
-`;
-
-exports[`Slack Element widgets renders an image element 1`] = `
-Object {
-  "alt_text": "Ravenclaw is obviously the best house.",
-  "image_url": "http://placekitten.com/700/500",
-  "type": "image",
-}
-`;
-
-exports[`Slack Element widgets renders an overflow menu element 1`] = `
-Object {
-  "action_id": "house-actions",
-  "options": Array [
-    Object {
-      "text": Object {
-        "emoji": true,
-        "text": "Why best?",
-        "type": "plain_text",
-      },
-      "value": "why-best-raven",
-    },
-    Object {
-      "text": Object {
-        "emoji": true,
-        "text": "Ping JK",
-        "type": "plain_text",
-      },
-      "value": "notify-author",
-    },
-  ],
-  "type": "overflow",
 }
 `;
 
@@ -684,7 +684,7 @@ Object {
 
 exports[`Slack Element widgets select input user element renders with opts that override 1`] = `
 Object {
-  "action_id": "channel",
+  "action_id": "user",
   "initial_user": "DPBMEQCM8",
   "placeholder": Object {
     "emoji": true,

--- a/packages/blocks/src/compositionObjects.ts
+++ b/packages/blocks/src/compositionObjects.ts
@@ -1,15 +1,11 @@
 import { MrkdwnElement, Option, PlainTextElement } from '@slack/types';
-import { mergeLeft } from 'ramda';
 
 import {
-  applyTruncations,
+  applyTruncationsWithOverrides,
   disallow,
   ellipsis,
   truncate,
   TruncateFunction,
-  TruncateOptions,
-  truncators,
-  truncLimits,
 } from './lengthHelpers';
 
 // Composition Object Helpers --- https://api.slack.com/reference/block-kit/composition-objects
@@ -29,27 +25,25 @@ export const PlainText = (text: string, emoji = true): PlainTextElement => ({
 // --- Confirm Object --- https://api.slack.com/reference/block-kit/composition-objects#confirm
 
 // --- Option Object --- https://api.slack.com/reference/block-kit/composition-objects#option
-const optionTruncates: TruncateOptions = {
-  text: [75, ellipsis],
-  value: [75, disallow],
-  description: [75, ellipsis],
-  url: [3000, truncate],
-};
-
 export const OptionObject = (
   text: string,
   value: string,
   optionBlock: Partial<Option> = {},
-  truncateFunctions: Record<string, TruncateFunction> = {},
+  overrideTruncators: Record<string, TruncateFunction> = {},
 ): Option =>
-  applyTruncations<Option>(
+  applyTruncationsWithOverrides<Option>(
     {
       text: PlainText(text),
       value,
       ...optionBlock,
-    } as Option,
-    mergeLeft(truncateFunctions, truncators(optionTruncates)),
-    truncLimits(optionTruncates),
+    },
+    {
+      text: [75, ellipsis],
+      value: [75, disallow],
+      description: [75, ellipsis],
+      url: [3000, truncate],
+    },
+    overrideTruncators,
   );
 
 // --- Option Group Object --- https://api.slack.com/reference/block-kit/composition-objects#option_group

--- a/packages/blocks/src/elements.spec.ts
+++ b/packages/blocks/src/elements.spec.ts
@@ -1,3 +1,5 @@
+import { flatten, repeat, takeLast } from 'ramda';
+
 import {
   Button,
   ChannelsSelectInputElement,
@@ -9,65 +11,156 @@ import {
   MultiUsersSelectInputElement,
   OptionObject,
   OverflowMenu,
+  PlainText,
   PlainTextInputElement,
   RadioInputElement,
   StaticSelectInputElement,
   UsersSelectInputElement,
 } from './elements';
+import { disallow, truncate } from './lengthHelpers';
+
+const dynamicText = '0123456789'.repeat(301); // 3010 characters long
 
 describe('Slack Element widgets', () => {
   const text = 'Ravenclaw is obviously the best house.';
   const url = 'http://placekitten.com/700/500';
   const buttonId = 'ravenAgree';
 
-  it('renders a button element', () => {
-    expect.assertions(1);
-    expect(Button(text, buttonId)).toMatchSnapshot();
-  });
+  describe('button', () => {
+    it('renders', () => {
+      expect.assertions(1);
+      expect(Button(text, buttonId)).toMatchSnapshot();
+    });
 
-  it('renders an image element', () => {
-    expect.assertions(1);
-    expect(Image(url, text)).toMatchSnapshot();
-  });
+    it('truncates ellipsis for text', () => {
+      expect.assertions(1);
+      const option = Button(dynamicText, buttonId);
+      expect(option.text).toEqual(PlainText(`${dynamicText.substr(0, 72)}...`));
+    });
 
-  it('renders an overflow menu element', () => {
-    expect.assertions(1);
-    expect(
-      OverflowMenu(
-        [
-          OptionObject('Why best?', 'why-best-raven'),
-          OptionObject('Ping JK', 'notify-author'),
-        ],
-        'house-actions',
-      ),
-    ).toMatchSnapshot();
-  });
-
-  it('renders a minimal plain-text input element', () => {
-    expect.assertions(1);
-    expect(
-      PlainTextInputElement(
-        'title',
-        'and the Prisoner of Azkaban',
-        'Enter a title',
-      ),
-    ).toMatchSnapshot();
-  });
-
-  it('renders a plain-text input element with initial value, placeholder, and opts', () => {
-    expect.assertions(1);
-    expect(
-      PlainTextInputElement(
-        'title',
-        'and the Prisoner of Azkaban',
-        'Enter a title',
+    it('allows override truncateOptions for too long value', () => {
+      expect.assertions(1);
+      const button = Button(
+        text,
+        buttonId,
+        { value: dynamicText },
         {
-          multiline: true,
-          min_length: 10,
-          max_length: 200,
+          value: truncate,
         },
-      ),
-    ).toMatchSnapshot();
+      );
+      expect(button.value).toHaveLength(2000);
+    });
+  });
+
+  describe('image', () => {
+    it('renders', () => {
+      expect.assertions(1);
+      expect(Image(url, text)).toMatchSnapshot();
+    });
+
+    it('truncates ellipsis for alt_text', () => {
+      expect.assertions(1);
+      const image = Image(url, dynamicText);
+      expect(image.alt_text).toEqual(`${dynamicText.substr(0, 1997)}...`);
+    });
+
+    it('allows override truncateOptions for too long url', () => {
+      expect.assertions(1);
+      expect(() => {
+        return Image(dynamicText, text, {
+          image_url: disallow,
+        });
+      }).toThrow();
+    });
+  });
+
+  describe('overflow menu', () => {
+    it('renders', () => {
+      expect.assertions(1);
+      expect(
+        OverflowMenu(
+          [
+            OptionObject('Why best?', 'why-best-raven'),
+            OptionObject('Ping JK', 'notify-author'),
+          ],
+          'house-actions',
+        ),
+      ).toMatchSnapshot();
+    });
+
+    it('truncates options', () => {
+      expect.assertions(1);
+      expect(
+        OverflowMenu(
+          repeat(OptionObject('Why best?', 'why-best-raven'), 10),
+          'house-actions',
+        ).options,
+      ).toHaveLength(5);
+    });
+
+    it('allows override truncateOptions function for too long options', () => {
+      expect.assertions(1);
+      const first3 = repeat(OptionObject('Why best?', 'why-best-raven'), 3);
+      const middle2 = repeat(OptionObject('Watch movie', 'movie-watch'), 2);
+      const last3 = repeat(OptionObject('Ping JK', 'notify-author'), 3);
+
+      expect(
+        OverflowMenu(
+          [...first3, ...middle2, ...last3],
+          'house-actions',
+          undefined,
+          {
+            options: takeLast, // should take last 5 (limit is passed)
+          },
+        ).options,
+      ).toEqual([...middle2, ...last3]);
+    });
+  });
+
+  describe('plaintext input', () => {
+    it('renders minimally', () => {
+      expect.assertions(1);
+      expect(
+        PlainTextInputElement(
+          'title',
+          'and the Prisoner of Azkaban',
+          'Enter a title',
+        ),
+      ).toMatchSnapshot();
+    });
+
+    it('renders with initial value, placeholder, and opts', () => {
+      expect.assertions(1);
+      expect(
+        PlainTextInputElement(
+          'title',
+          'and the Prisoner of Azkaban',
+          'Enter a title',
+          {
+            multiline: true,
+            min_length: 10,
+            max_length: 200,
+          },
+        ),
+      ).toMatchSnapshot();
+    });
+
+    it('truncates placeholder and initial_value', () => {
+      expect.assertions(2);
+      const truncatedString = `${dynamicText.substr(0, 147)}...`;
+      const truncated = PlainTextInputElement('TBD', dynamicText, dynamicText);
+      expect(truncated.initial_value).toEqual(truncatedString);
+      expect(truncated.placeholder?.text).toEqual(truncatedString);
+    });
+
+    it('allows override truncateOptions for too long initial_value', () => {
+      expect.assertions(1);
+      expect(
+        PlainTextInputElement('TBD', dynamicText, undefined, undefined, {
+          initial_value: truncate,
+        }).initial_value,
+      ).toHaveLength(150);
+    });
   });
 
   const options = [
@@ -77,6 +170,8 @@ describe('Slack Element widgets', () => {
   ];
 
   describe('checkbox input element', () => {
+    const tooLongOptions = flatten(repeat(options, 5)); // 15 options
+
     it('renders a minimal example', () => {
       expect.assertions(1);
       expect(CheckboxInputElement('title', options)).toMatchSnapshot();
@@ -97,9 +192,34 @@ describe('Slack Element widgets', () => {
         }),
       ).toMatchSnapshot();
     });
+
+    it('truncates options', () => {
+      expect.assertions(2);
+      const manyOptions = tooLongOptions;
+      const truncated = CheckboxInputElement('title', manyOptions, manyOptions);
+      expect(truncated.options).toHaveLength(10);
+      expect(truncated.initial_options).toHaveLength(10);
+    });
+
+    it('allows override truncateOptions for too long initial_options', () => {
+      expect.assertions(1);
+      expect(() => {
+        return CheckboxInputElement(
+          'title',
+          options,
+          tooLongOptions,
+          undefined,
+          {
+            initial_options: disallow,
+          },
+        );
+      }).toThrow();
+    });
   });
 
   describe('radio input element', () => {
+    const tooLongOptions = flatten(repeat(options, 5)); // 15 options
+
     it('renders a minimal example', () => {
       expect.assertions(1);
       expect(RadioInputElement('title', options)).toMatchSnapshot();
@@ -118,9 +238,32 @@ describe('Slack Element widgets', () => {
         }),
       ).toMatchSnapshot();
     });
+
+    it('truncates options', () => {
+      expect.assertions(1);
+      const manyOptions = tooLongOptions;
+      const truncated = RadioInputElement('title', manyOptions);
+      expect(truncated.options).toHaveLength(10);
+    });
+
+    it('allows override truncateOptions for too long options', () => {
+      expect.assertions(1);
+      expect(() => {
+        return RadioInputElement(
+          'title',
+          tooLongOptions,
+          undefined,
+          undefined,
+          {
+            options: disallow,
+          },
+        );
+      }).toThrow();
+    });
   });
 
   describe('select input', () => {
+    const tooLongOptions = flatten(repeat(options, 50)); // 150 long
     describe('static element', () => {
       it('renders a minimal example', () => {
         expect.assertions(1);
@@ -155,6 +298,32 @@ describe('Slack Element widgets', () => {
           ),
         ).toMatchSnapshot();
       });
+
+      it('truncates options', () => {
+        expect.assertions(1);
+        const truncated = StaticSelectInputElement(
+          'title',
+          'Select a book',
+          tooLongOptions,
+        );
+        expect(truncated.options).toHaveLength(100);
+      });
+
+      it('allows override truncateOptions for too long options', () => {
+        expect.assertions(1);
+        expect(() => {
+          return StaticSelectInputElement(
+            'title',
+            'Select a book',
+            tooLongOptions,
+            undefined,
+            undefined,
+            {
+              options: disallow,
+            },
+          );
+        }).toThrow();
+      });
     });
 
     describe('channels element', () => {
@@ -179,6 +348,29 @@ describe('Slack Element widgets', () => {
             initial_channel: 'GRK5NTHV2',
           }),
         ).toMatchSnapshot();
+      });
+
+      it('truncates placeholder with ellipsis', () => {
+        expect.assertions(1);
+        const truncatedString = `${dynamicText.substr(0, 147)}...`;
+        expect(
+          ChannelsSelectInputElement('channel', dynamicText).placeholder?.text,
+        ).toEqual(truncatedString);
+      });
+
+      it('allows override truncateOptions for too long placeholder', () => {
+        expect.assertions(1);
+        expect(
+          ChannelsSelectInputElement(
+            'channel',
+            dynamicText,
+            undefined,
+            undefined,
+            {
+              placeholder: truncate,
+            },
+          ).placeholder?.text,
+        ).toHaveLength(150);
       });
     });
 
@@ -217,6 +409,30 @@ describe('Slack Element widgets', () => {
           ),
         ).toMatchSnapshot();
       });
+
+      it('truncates placeholder with ellipsis', () => {
+        expect.assertions(1);
+        const truncatedString = `${dynamicText.substr(0, 147)}...`;
+        expect(
+          ConversationsSelectInputElement('conversation', dynamicText)
+            .placeholder?.text,
+        ).toEqual(truncatedString);
+      });
+
+      it('allows override truncateOptions for too long placeholder', () => {
+        expect.assertions(1);
+        expect(
+          ConversationsSelectInputElement(
+            'conversation',
+            dynamicText,
+            undefined,
+            undefined,
+            {
+              placeholder: truncate,
+            },
+          ).placeholder?.text,
+        ).toHaveLength(150);
+      });
     });
 
     describe('user element', () => {
@@ -237,10 +453,27 @@ describe('Slack Element widgets', () => {
       it('renders with opts that override', () => {
         expect.assertions(1);
         expect(
-          UsersSelectInputElement('channel', 'Select a user', 'DPJ215Q65', {
+          UsersSelectInputElement('user', 'Select a user', 'DPJ215Q65', {
             initial_user: 'DPBMEQCM8',
           }),
         ).toMatchSnapshot();
+      });
+
+      it('truncates placeholder with ellipsis', () => {
+        expect.assertions(1);
+        const truncatedString = `${dynamicText.substr(0, 147)}...`;
+        expect(
+          UsersSelectInputElement('user', dynamicText).placeholder?.text,
+        ).toEqual(truncatedString);
+      });
+
+      it('allows override truncateOptions for too long placeholder', () => {
+        expect.assertions(1);
+        expect(
+          UsersSelectInputElement('user', dynamicText, undefined, undefined, {
+            placeholder: truncate,
+          }).placeholder?.text,
+        ).toHaveLength(150);
       });
     });
   });
@@ -275,6 +508,30 @@ describe('Slack Element widgets', () => {
             },
           ),
         ).toMatchSnapshot();
+      });
+
+      it('truncates placeholder with ellipsis', () => {
+        expect.assertions(1);
+        const truncatedString = `${dynamicText.substr(0, 147)}...`;
+        expect(
+          MultiChannelsSelectInputElement('channels', dynamicText).placeholder
+            ?.text,
+        ).toEqual(truncatedString);
+      });
+
+      it('allows override truncateOptions for too long placeholder', () => {
+        expect.assertions(1);
+        expect(
+          MultiChannelsSelectInputElement(
+            'channel',
+            dynamicText,
+            undefined,
+            undefined,
+            {
+              placeholder: truncate,
+            },
+          ).placeholder?.text,
+        ).toHaveLength(150);
       });
     });
 
@@ -313,6 +570,30 @@ describe('Slack Element widgets', () => {
           ),
         ).toMatchSnapshot();
       });
+
+      it('truncates placeholder with ellipsis', () => {
+        expect.assertions(1);
+        const truncatedString = `${dynamicText.substr(0, 147)}...`;
+        expect(
+          MultiConversationsSelectInputElement('conversations', dynamicText)
+            .placeholder?.text,
+        ).toEqual(truncatedString);
+      });
+
+      it('allows override truncateOptions for too long placeholder', () => {
+        expect.assertions(1);
+        expect(
+          MultiConversationsSelectInputElement(
+            'conversations',
+            dynamicText,
+            undefined,
+            undefined,
+            {
+              placeholder: truncate,
+            },
+          ).placeholder?.text,
+        ).toHaveLength(150);
+      });
     });
 
     describe('users element', () => {
@@ -337,6 +618,29 @@ describe('Slack Element widgets', () => {
             initial_users: ['DPBMEQCM8'],
           }),
         ).toMatchSnapshot();
+      });
+
+      it('truncates placeholder with ellipsis', () => {
+        expect.assertions(1);
+        const truncatedString = `${dynamicText.substr(0, 147)}...`;
+        expect(
+          MultiUsersSelectInputElement('users', dynamicText).placeholder?.text,
+        ).toEqual(truncatedString);
+      });
+
+      it('allows override truncateOptions for too long placeholder', () => {
+        expect.assertions(1);
+        expect(
+          MultiUsersSelectInputElement(
+            'users',
+            dynamicText,
+            undefined,
+            undefined,
+            {
+              placeholder: truncate,
+            },
+          ).placeholder?.text,
+        ).toHaveLength(150);
       });
     });
   });

--- a/packages/blocks/src/elements.ts
+++ b/packages/blocks/src/elements.ts
@@ -17,6 +17,14 @@ import {
 } from '@slack/types';
 
 import { PlainText } from './compositionObjects';
+import {
+  applyTruncationsWithOverrides,
+  disallow,
+  ellipsis,
+  truncate,
+  TruncateFunction,
+  TruncateOptions,
+} from './lengthHelpers';
 
 export * from './compositionObjects';
 
@@ -31,12 +39,25 @@ export const Button = (
   text: string,
   action_id: string,
   buttonBlock?: Partial<TButton>,
-): TButton => ({
-  type: 'button',
-  text: PlainText(text),
-  action_id,
-  ...buttonBlock,
-});
+  overrideTruncators: Record<string, TruncateFunction> = {},
+): TButton =>
+  applyTruncationsWithOverrides<TButton>(
+    {
+      type: 'button',
+      text: PlainText(text),
+      action_id,
+      ...buttonBlock,
+    },
+    {
+      text: [75, ellipsis],
+      action_id: [255, disallow],
+      url: [3000, truncate],
+      value: [2000, disallow],
+      options: [10, truncate],
+      // TODO: what to do with confirm validation?
+    },
+    overrideTruncators,
+  );
 
 // --- Checkbox Group --- https://api.slack.com/reference/block-kit/block-elements#checkboxes
 export const CheckboxInputElement = (
@@ -44,23 +65,50 @@ export const CheckboxInputElement = (
   options: Checkboxes['options'],
   initial_options?: Checkboxes['initial_options'],
   opts: Partial<Checkboxes> = {},
+  overrideTruncators: Record<string, TruncateFunction> = {},
 ): Checkboxes =>
-  InputElement<Checkboxes>('checkboxes')(action_id, {
-    options,
-    initial_options,
-    ...opts,
-  });
+  applyTruncationsWithOverrides<Checkboxes>(
+    InputElement<Checkboxes>('checkboxes')(action_id, {
+      options,
+      initial_options,
+      ...opts,
+    }),
+    {
+      action_id: [255, disallow],
+      // not in docs, but tested and validated that this breaks after 10
+      options: [10, truncate],
+      initial_options: [10, truncate],
+    },
+    overrideTruncators,
+  );
 
 // --- Date Picker Element --- https://api.slack.com/reference/block-kit/block-elements#datepicker
 
-// --- Image Element --- https://api.slack.com/reference/block-kit/block-elements#image
-export const Image = (image_url: string, alt_text: string): ImageElement => ({
-  type: 'image',
-  image_url,
-  alt_text,
-});
+// --- Image Element --- https://api.slack.com/reference/block-kit/block-elements#image (this is both a block element and a block)
+export const Image = (
+  image_url: string,
+  alt_text: string,
+  overrideTruncators: Record<string, TruncateFunction> = {},
+): ImageElement =>
+  applyTruncationsWithOverrides<ImageElement>(
+    {
+      type: 'image',
+      image_url,
+      alt_text,
+    },
+    { image_url: [3000, truncate], alt_text: [2000, ellipsis] },
+    overrideTruncators,
+  );
 
 // --- Multi-select Menu Element --- https://api.slack.com/reference/block-kit/block-elements#multi_select
+
+const multiSelectTruncateOptions: TruncateOptions = {
+  action_id: [255, disallow],
+  placeholder: [150, ellipsis],
+  options: [100, truncate],
+  option_groups: [100, truncate],
+  initial_options: [100, truncate],
+};
 
 // https://api.slack.com/reference/block-kit/block-elements#static_multi_select
 
@@ -70,12 +118,17 @@ export const MultiChannelsSelectInputElement = (
   placeholder: string,
   initial_channels?: MultiChannelsSelect['initial_channels'],
   opts: Partial<MultiChannelsSelect> = {},
+  overrideTruncators: Record<string, TruncateFunction> = {},
 ): MultiChannelsSelect =>
-  InputElement<MultiChannelsSelect>('multi_channels_select')(action_id, {
-    placeholder: PlainText(placeholder),
-    initial_channels,
-    ...opts,
-  });
+  applyTruncationsWithOverrides<MultiChannelsSelect>(
+    InputElement<MultiChannelsSelect>('multi_channels_select')(action_id, {
+      placeholder: PlainText(placeholder),
+      initial_channels,
+      ...opts,
+    }),
+    multiSelectTruncateOptions,
+    overrideTruncators,
+  );
 
 // https://api.slack.com/reference/block-kit/block-elements#conversation_multi_select
 export const MultiConversationsSelectInputElement = (
@@ -83,14 +136,19 @@ export const MultiConversationsSelectInputElement = (
   placeholder: string,
   initial_conversations?: MultiConversationsSelect['initial_conversations'],
   opts: Partial<MultiConversationsSelect> = {},
+  overrideTruncators: Record<string, TruncateFunction> = {},
 ): MultiConversationsSelect =>
-  InputElement<MultiConversationsSelect>('multi_conversations_select')(
-    action_id,
-    {
-      placeholder: PlainText(placeholder),
-      initial_conversations,
-      ...opts,
-    },
+  applyTruncationsWithOverrides<MultiConversationsSelect>(
+    InputElement<MultiConversationsSelect>('multi_conversations_select')(
+      action_id,
+      {
+        placeholder: PlainText(placeholder),
+        initial_conversations,
+        ...opts,
+      },
+    ),
+    multiSelectTruncateOptions,
+    overrideTruncators,
   );
 
 // https://api.slack.com/reference/block-kit/block-elements#users_multi_select
@@ -99,24 +157,38 @@ export const MultiUsersSelectInputElement = (
   placeholder: string,
   initial_users?: MultiUsersSelect['initial_users'],
   opts: Partial<MultiUsersSelect> = {},
+  overrideTruncators: Record<string, TruncateFunction> = {},
 ): MultiUsersSelect =>
-  InputElement<MultiUsersSelect>('multi_users_select')(action_id, {
-    placeholder: PlainText(placeholder),
-    initial_users,
-    ...opts,
-  });
+  applyTruncationsWithOverrides<MultiUsersSelect>(
+    InputElement<MultiUsersSelect>('multi_users_select')(action_id, {
+      placeholder: PlainText(placeholder),
+      initial_users,
+      ...opts,
+    }),
+    multiSelectTruncateOptions,
+    overrideTruncators,
+  );
 
 // --- Overflow Menu Element --- https://api.slack.com/reference/block-kit/block-elements#overflow
 export const OverflowMenu = (
   options: Option[],
   action_id: string,
   menuBlock?: Partial<Overflow>,
-): Overflow => ({
-  type: 'overflow',
-  options,
-  action_id,
-  ...menuBlock,
-});
+  overrideTruncators: Record<string, TruncateFunction> = {},
+): Overflow =>
+  applyTruncationsWithOverrides<Overflow>(
+    {
+      type: 'overflow',
+      options,
+      action_id,
+      ...menuBlock,
+    },
+    {
+      action_id: [255, disallow],
+      options: [5, truncate],
+    },
+    overrideTruncators,
+  );
 
 // --- Plain-text Input Element --- https://api.slack.com/reference/block-kit/block-elements#input
 export const PlainTextInputElement = (
@@ -124,12 +196,22 @@ export const PlainTextInputElement = (
   initial_value?: PlainTextInput['initial_value'],
   placeholder?: string,
   opts: Partial<PlainTextInput> = {},
+  overrideTruncators: Record<string, TruncateFunction> = {},
 ): PlainTextInput =>
-  InputElement<PlainTextInput>('plain_text_input')(action_id, {
-    initial_value,
-    placeholder: placeholder ? PlainText(placeholder) : undefined,
-    ...opts,
-  });
+  applyTruncationsWithOverrides<PlainTextInput>(
+    InputElement<PlainTextInput>('plain_text_input')(action_id, {
+      initial_value,
+      placeholder: placeholder ? PlainText(placeholder) : undefined,
+      ...opts,
+    }),
+    {
+      action_id: [255, disallow],
+      placeholder: [150, ellipsis],
+      // note, initial_value not documented, but max 150 based on testing
+      initial_value: [150, ellipsis],
+    },
+    overrideTruncators,
+  );
 
 // --- Radio Button Group Element --- https://api.slack.com/reference/block-kit/block-elements#radio
 export const RadioInputElement = (
@@ -137,27 +219,49 @@ export const RadioInputElement = (
   options: RadioButtons['options'],
   initial_option?: RadioButtons['initial_option'],
   opts: Partial<RadioButtons> = {},
+  overrideTruncators: Record<string, TruncateFunction> = {},
 ): RadioButtons =>
-  InputElement<RadioButtons>('radio_buttons')(action_id, {
-    options,
-    initial_option,
-    ...opts,
-  });
+  applyTruncationsWithOverrides<RadioButtons>(
+    InputElement<RadioButtons>('radio_buttons')(action_id, {
+      options,
+      initial_option,
+      ...opts,
+    }),
+    {
+      action_id: [255, disallow],
+      // not in docs, but tested and validated that this breaks after 10
+      options: [10, truncate],
+    },
+    overrideTruncators,
+  );
 
 // --- Select Menu Element --- https://api.slack.com/reference/block-kit/block-elements#select
+
+const selectTruncateOptions: TruncateOptions = {
+  placeholder: [150, ellipsis],
+  action_id: [255, disallow],
+  options: [100, truncate],
+  option_groups: [100, truncate],
+};
+
 export const StaticSelectInputElement = (
   action_id: StaticSelect['action_id'],
   placeholder: string,
   options: StaticSelect['options'],
   initial_option?: StaticSelect['initial_option'],
   opts: Partial<StaticSelect> = {},
+  overrideTruncators: Record<string, TruncateFunction> = {},
 ): StaticSelect =>
-  InputElement<StaticSelect>('static_select')(action_id, {
-    placeholder: PlainText(placeholder),
-    options,
-    initial_option,
-    ...opts,
-  });
+  applyTruncationsWithOverrides<StaticSelect>(
+    InputElement<StaticSelect>('static_select')(action_id, {
+      placeholder: PlainText(placeholder),
+      options,
+      initial_option,
+      ...opts,
+    }),
+    selectTruncateOptions,
+    overrideTruncators,
+  );
 
 // https://api.slack.com/reference/block-kit/block-elements#channel_select
 export const ChannelsSelectInputElement = (
@@ -165,12 +269,17 @@ export const ChannelsSelectInputElement = (
   placeholder: string,
   initial_channel?: ChannelsSelect['initial_channel'],
   opts: Partial<ChannelsSelect> = {},
+  overrideTruncators: Record<string, TruncateFunction> = {},
 ): ChannelsSelect =>
-  InputElement<ChannelsSelect>('channels_select')(action_id, {
-    placeholder: PlainText(placeholder),
-    initial_channel,
-    ...opts,
-  });
+  applyTruncationsWithOverrides<ChannelsSelect>(
+    InputElement<ChannelsSelect>('channels_select')(action_id, {
+      placeholder: PlainText(placeholder),
+      initial_channel,
+      ...opts,
+    }),
+    selectTruncateOptions,
+    overrideTruncators,
+  );
 
 // https://api.slack.com/reference/block-kit/block-elements#conversation_select
 export const ConversationsSelectInputElement = (
@@ -178,12 +287,17 @@ export const ConversationsSelectInputElement = (
   placeholder: string,
   initial_conversation?: ConversationsSelect['initial_conversation'],
   opts: Partial<ConversationsSelect> = {},
+  overrideTruncators: Record<string, TruncateFunction> = {},
 ): ConversationsSelect =>
-  InputElement<ConversationsSelect>('conversations_select')(action_id, {
-    placeholder: PlainText(placeholder),
-    initial_conversation,
-    ...opts,
-  });
+  applyTruncationsWithOverrides<ConversationsSelect>(
+    InputElement<ConversationsSelect>('conversations_select')(action_id, {
+      placeholder: PlainText(placeholder),
+      initial_conversation,
+      ...opts,
+    }),
+    selectTruncateOptions,
+    overrideTruncators,
+  );
 
 // https://api.slack.com/reference/block-kit/block-elements#users_select
 export const UsersSelectInputElement = (
@@ -191,9 +305,14 @@ export const UsersSelectInputElement = (
   placeholder: string,
   initial_user?: UsersSelect['initial_user'],
   opts: Partial<UsersSelect> = {},
+  overrideTruncators: Record<string, TruncateFunction> = {},
 ): UsersSelect =>
-  InputElement<UsersSelect>('users_select')(action_id, {
-    placeholder: PlainText(placeholder),
-    initial_user,
-    ...opts,
-  });
+  applyTruncationsWithOverrides<UsersSelect>(
+    InputElement<UsersSelect>('users_select')(action_id, {
+      placeholder: PlainText(placeholder),
+      initial_user,
+      ...opts,
+    }),
+    selectTruncateOptions,
+    overrideTruncators,
+  );

--- a/packages/blocks/src/elements.ts
+++ b/packages/blocks/src/elements.ts
@@ -54,7 +54,6 @@ export const Button = (
       url: [3000, truncate],
       value: [2000, disallow],
       options: [10, truncate],
-      // TODO: what to do with confirm validation?
     },
     overrideTruncators,
   );

--- a/packages/blocks/src/lengthHelpers.ts
+++ b/packages/blocks/src/lengthHelpers.ts
@@ -58,11 +58,12 @@ export const identity = <T>(limit: number, value: T): T => R.identity(value);
 
 /**
  * truncates by just taking the first `limit` elements of `value`
- * works for list or string
+ * works for list string, or object with text property
  */
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore
-export const truncate = <T>(limit: number, value: T): T => take(limit)(value);
+export const truncate = <T>(limit: number, value: T): T =>
+  ifElse(has('text'), over(lensProp('text'), take(limit)), take(limit))(value);
 
 const longerThan = curry((limit: number, value: any): boolean =>
   pipe<any, number, boolean>(prop('length'), lt(limit))(value),

--- a/packages/blocks/src/lengthHelpers.ts
+++ b/packages/blocks/src/lengthHelpers.ts
@@ -8,6 +8,7 @@ import R, {
   lensProp,
   lt,
   mapObjIndexed,
+  mergeLeft,
   over,
   pipe,
   prop,
@@ -101,11 +102,8 @@ export const truncators: (
 
 /**
  * mostly internal function for building blocks - takes the element `obj` and
- * applies the truncation `functions` to each limited field iff that field's length is greater than its
- * respective limit for that block
- * @param obj
- * @param functions
- * @param limits
+ * applies the truncation `functions` to each limited field iff that field's
+ * length is greater than its respective limit for that block
  */
 export const applyTruncations = <T extends Record<string, any>>(
   obj: T,
@@ -125,3 +123,20 @@ export const applyTruncations = <T extends Record<string, any>>(
     return value;
   }, obj);
 };
+
+/**
+ * mostly internal function for building blocks - takes the element `obj` and
+ * any user provided overrides for the truncate functions and
+ * applies the truncation `functions` to each limited field iff that field's
+ * length is greater than its respective limit for that block
+ */
+export const applyTruncationsWithOverrides = <T extends Record<string, any>>(
+  obj: T,
+  defaultTruncateOptions: TruncateOptions,
+  overrides: Record<string, TruncateFunction>,
+): T =>
+  applyTruncations(
+    obj,
+    mergeLeft(overrides, truncators(defaultTruncateOptions)),
+    truncLimits(defaultTruncateOptions),
+  );

--- a/packages/blocks/src/lengthHelpers.ts
+++ b/packages/blocks/src/lengthHelpers.ts
@@ -103,8 +103,8 @@ export const truncators: (
 
 /**
  * mostly internal function for building blocks - takes the element `obj` and
- * applies the truncation `functions` to each limited field iff that field's
- * length is greater than its respective limit for that block
+ * applies the `truncateFns` to each limited field if and only if
+ * that field's length is greater than its respective limit for that block
  */
 export const applyTruncations = <T extends Record<string, any>>(
   obj: T,
@@ -127,8 +127,8 @@ export const applyTruncations = <T extends Record<string, any>>(
 
 /**
  * mostly internal function for building blocks - takes the element `obj` and
- * any user provided overrideFns and applies those truncation functions
- * to each limited field iff that field's length is greater than the provided limit
+ * any user provided `overrideFns` and applies those truncation functions
+ * to each limited field if and only if that field's length is greater than the provided limit
  */
 export const applyTruncationsWithOverrides = <T extends Record<string, any>>(
   obj: T,

--- a/packages/blocks/src/lengthHelpers.ts
+++ b/packages/blocks/src/lengthHelpers.ts
@@ -108,17 +108,17 @@ export const truncators: (
  */
 export const applyTruncations = <T extends Record<string, any>>(
   obj: T,
-  functions: Record<string, TruncateFunction>,
+  truncateFns: Record<string, TruncateFunction>,
   limits: Record<string, number>,
 ): T => {
-  const truncateKeys = Object.keys(functions);
+  const truncateKeys = Object.keys(truncateFns);
 
-  // for each key in object, apply the function in functions associated with that key if exists
+  // for each key in object, apply the function in truncateFns associated with that key if exists
   // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
   // @ts-ignore
   return mapObjIndexed(<J>(value: J, key: string): J => {
     if (truncateKeys.includes(key) && isTooLongForBlock(limits[key])(value)) {
-      return functions[key](limits[key], value);
+      return truncateFns[key](limits[key], value);
     }
 
     return value;
@@ -127,17 +127,16 @@ export const applyTruncations = <T extends Record<string, any>>(
 
 /**
  * mostly internal function for building blocks - takes the element `obj` and
- * any user provided overrides for the truncate functions and
- * applies the truncation `functions` to each limited field iff that field's
- * length is greater than its respective limit for that block
+ * any user provided overrideFns and applies those truncation functions
+ * to each limited field iff that field's length is greater than the provided limit
  */
 export const applyTruncationsWithOverrides = <T extends Record<string, any>>(
   obj: T,
   defaultTruncateOptions: TruncateOptions,
-  overrides: Record<string, TruncateFunction>,
+  overrideFns: Record<string, TruncateFunction>,
 ): T =>
   applyTruncations(
     obj,
-    mergeLeft(overrides, truncators(defaultTruncateOptions)),
+    mergeLeft(overrideFns, truncators(defaultTruncateOptions)),
     truncLimits(defaultTruncateOptions),
   );


### PR DESCRIPTION
**Related PRs**  
Continuation of #75 

**What does this PR do?**  
- sets up all elements to limit fields as appropriate and enable users to customize the truncation
- provides helper to more easily set up limits for fields on blocks
- updates truncate helper to also accept text object

**Description of Changes**  
Basically goes through all of the currently-implemented elements, adds fields with appropriate limits and associated truncation functions, and then applies them as appropriate with any user-overridden truncate functions.

Still one more PR to do the same with blocks, and/or (maybe separate PR) for the high-level abstractions (e.g. modal view/blocks array 100 block limit).

**What gif most accurately describes how I feel towards this PR?**  

![](https://media2.giphy.com/media/l0HUpcIQzIb4gvMJi/giphy.gif?cid=5a38a5a292f21a26af263d2fb77f8a28117478afe8bc0103&rid=giphy.gif)
