### PR TITLE
update admin usergroups for 5.9 webclient

### DIFF
--- a/packages/bolt-interactions/package.json
+++ b/packages/bolt-interactions/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@slack-wrench/fixtures": "^2.2.1",
     "@slack-wrench/jest-bolt-receiver": "^2.0.1",
-    "@slack-wrench/jest-mock-web-client": "^1.1.1",
+    "@slack-wrench/jest-mock-web-client": "^1.2.0",
     "@slack/bolt": "^1.4.1",
     "delay": "^4.3.0"
   },

--- a/packages/jest-bolt-receiver/package.json
+++ b/packages/jest-bolt-receiver/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@slack-wrench/fixtures": "^2.0.1",
-    "@slack-wrench/jest-mock-web-client": "^1.1.1",
+    "@slack-wrench/jest-mock-web-client": "^1.2.0",
     "@slack-wrench/standards": "^1.1.0",
     "delay": "^4.3.0"
   },

--- a/packages/jest-mock-web-client/package.json
+++ b/packages/jest-mock-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack-wrench/jest-mock-web-client",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Mock @slack/web-api for jest",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -16,10 +16,10 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@slack-wrench/standards": "^1.1.0",
-    "@slack/web-api": "~5.8.0"
+    "@slack/web-api": "~5.9.0"
   },
   "peerDependencies": {
-    "@slack/web-api": "~5.8.0"
+    "@slack/web-api": "~5.9.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-mock-web-client/src/index.ts
+++ b/packages/jest-mock-web-client/src/index.ts
@@ -64,6 +64,11 @@ export class MockWebClient implements Partial<WebClient> {
         setName: mockApi(),
       },
     },
+    usergroups: {
+      addChannels: mockApi(),
+      listChannels: mockApi(),
+      removeChannels: mockApi(),
+    },
     users: {
       session: {
         reset: mockApi(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1392,10 +1392,27 @@
   resolved "https://registry.yarnpkg.com/@slack/types/-/types-1.6.0.tgz#7b5f08db824d9853cbf6c2de1c08865ba6ce346f"
   integrity sha512-SrrAD/ZxDN4szQ35V/mY2TvKSyGsUWP8def1C8NMg9AvdYG0VyaL5f+Dd6jw8STosMFXd3zqjekMowT9LB9/IQ==
 
-"@slack/web-api@^5.6.0", "@slack/web-api@^5.8.0", "@slack/web-api@~5.8.0":
+"@slack/web-api@^5.6.0", "@slack/web-api@^5.8.0":
   version "5.8.1"
   resolved "https://registry.yarnpkg.com/@slack/web-api/-/web-api-5.8.1.tgz#90daba7ee2fb5a928a5d34c57fff0cf9ba5ada8c"
   integrity sha512-MONzkjWOXV39Dejo8B9WSl/F0dxcVh9wyeW6R0jf6T6BhwN4f24iErYtTh19g+MRhb0oiyeKfnFsJTSKQulfDA==
+  dependencies:
+    "@slack/logger" ">=1.0.0 <3.0.0"
+    "@slack/types" "^1.2.1"
+    "@types/is-stream" "^1.1.0"
+    "@types/node" ">=8.9.0"
+    "@types/p-queue" "^2.3.2"
+    axios "^0.19.0"
+    eventemitter3 "^3.1.0"
+    form-data "^2.5.0"
+    is-stream "^1.1.0"
+    p-queue "^2.4.2"
+    p-retry "^4.0.0"
+
+"@slack/web-api@~5.9.0":
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/@slack/web-api/-/web-api-5.9.0.tgz#13ce1eecc405c3972e6037d54338344d7859a3b5"
+  integrity sha512-gIRvuA9wGtp4S/Zc+zfT59IaGHYzNxjob2QxoJlc3JZ3BLuPMa6Lw81YBV0xutJvUVFPX2ytW27KAUakvi5ZMA==
   dependencies:
     "@slack/logger" ">=1.0.0 <3.0.0"
     "@slack/types" "^1.2.1"


### PR DESCRIPTION
**What does this PR do?**  
Bumps web-client version to 5.9 and updates provided APIs in mock web client

**What gif most accurately describes how I feel towards this PR?**  
![](https://media2.giphy.com/media/ZjwuOFp6xzrDG/giphy.gif?cid=5a38a5a266c9b5a92b67bbb3f916dadb2a2787ea64391fb0&rid=giphy.gif)

