### PR TITLE
chore: allow slack/bolt 3.x

### DIFF
--- a/packages/koa-bolt/package.json
+++ b/packages/koa-bolt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack-wrench/koa-bolt",
-  "version": "1.2.1",
+  "version": "1.2.0",
   "description": "Run bolt as koa middleware",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -25,7 +25,7 @@
     "koa-compose": "^4.0.0"
   },
   "devDependencies": {
-    "@slack/bolt": "^2.1.1",
+    "@slack/bolt": "^3.3.0",
     "@slack-wrench/fixtures": "^2.0.1",
     "koa": "^2.11.0",
     "koa-compose": "^4.1.0",

--- a/packages/koa-bolt/package.json
+++ b/packages/koa-bolt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack-wrench/koa-bolt",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Run bolt as koa middleware",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/koa-bolt/package.json
+++ b/packages/koa-bolt/package.json
@@ -20,7 +20,7 @@
     "@types/koa__router": "^8.0.2"
   },
   "peerDependencies": {
-    "@slack/bolt": ">=1.0.0 <3.0.0",
+    "@slack/bolt": ">=1.0.0 <4.0.0",
     "koa": "^2.0.0",
     "koa-compose": "^4.0.0"
   },


### PR DESCRIPTION
**Related Issue**  
Supports #99 

**Related PRs**  
This PR is not dependent on any other PR

**What does this PR do?**  
Removes a warning about peer dependencies for @slack/bolt v3

**Description of Changes**  
Allows using this library with bolt v3

**What gif most accurately describes how I feel towards this PR?**  
![Example of a gif](https://media.giphy.com/media/QTdJhJsdHys8w/giphy.gif)
