### PR TITLE
fix: 🐛 removes char limit on initial_value for PlainTextInput

### DIFF
--- a/packages/blocks/src/elements.spec.ts
+++ b/packages/blocks/src/elements.spec.ts
@@ -186,21 +186,11 @@ describe('Slack Element widgets', () => {
       ).toMatchSnapshot();
     });
 
-    it('truncates placeholder and initial_value', () => {
-      expect.assertions(2);
+    it('truncates placeholder', () => {
+      expect.assertions(1);
       const truncatedString = `${dynamicText.substr(0, 148)} …`;
       const truncated = PlainTextInput('TBD', dynamicText, dynamicText);
-      expect(truncated.initial_value).toEqual(truncatedString);
       expect(truncated.placeholder?.text).toEqual(truncatedString);
-    });
-
-    it('allows override LimitOpts for too long initial_value', () => {
-      expect.assertions(1);
-      expect(
-        PlainTextInput('TBD', dynamicText, undefined, undefined, {
-          initial_value: truncate,
-        }).initial_value,
-      ).toHaveLength(150);
     });
   });
 

--- a/packages/blocks/src/elements.ts
+++ b/packages/blocks/src/elements.ts
@@ -311,8 +311,6 @@ export const PlainTextInput = (
     {
       action_id: [255, disallow],
       placeholder: [150, ellipsis],
-      // note, initial_value not documented, but max 150 based on testing
-      initial_value: [150, ellipsis],
     },
     limiterOverrides,
   );


### PR DESCRIPTION
**Related Issue**  
Supports #105

**Related PRs**  
This PR is not dependent on any other PR

**What does this PR do?**  
Slack Wrench erroneously truncates a `PlainTextInput` to 150 characters. I have tested this, and asked the Slack Blocks team about this - they confirm no such limit exists.

**Description of Changes**  
This PR removes the limit on `initial_value` for `PlainTextInput`, and fixes up the related tests.

**What gif most accurately describes how I feel towards this PR?**  
![tenor](https://user-images.githubusercontent.com/2505584/116834737-c8943400-ac02-11eb-8107-758b815afc6c.gif)

