### PR TITLE
Support newer Slack and Jest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
   "workspaces": {
     "packages": [
       "packages/*"
+    ],
+    "nohoist": [
+      "**/jest-image-snapshot",
+      "**/@types/jest-image-snapshot"
     ]
   }
 }

--- a/packages/jest-mock-web-client/package.json
+++ b/packages/jest-mock-web-client/package.json
@@ -19,7 +19,8 @@
     "@slack/web-api": "^5.10.0"
   },
   "peerDependencies": {
-    "@slack/web-api": "^5.10.0"
+    "@slack/web-api": ">=5.10.0",
+    "jest": ">=20"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-mock-web-client/src/index.spec.ts
+++ b/packages/jest-mock-web-client/src/index.spec.ts
@@ -85,4 +85,10 @@ describe('Mocked @slack/web-api', () => {
     expect(MockedWebClient.mock.instances.length).toEqual(1);
     expect(MockedWebClient.mock.instances[0]).toBe(client);
   });
+
+  it('allows MockedWebClient to be constructable', () => {
+    expect.assertions(1);
+    const instance = new MockedWebClient();
+    expect(jest.isMockFunction(instance.chat.postMessage)).toBeTruthy();
+  });
 });


### PR DESCRIPTION
**Related Issue**  
Supports #118, #104

**Related PRs**  
This PR is not dependent on any other PR

**What does this PR do?**  
This is an attempt, based on the discussion in #118, to make `jest-mock-web-client` compatible with newer Slack and Jest versions, and in general with a wider array of versions by making it a bit more abstract — it builds its typings dynamically by mapping those of the installed Slack version. While I was at it, I wound up solving #104.

**Description of Changes**  
This implementation is a bit complicated, partially because I tried to preserve `MockWebClient` as a class, rather than making it just a type. (If just a type is OK, this can definitely be simplified a bit!)

The main idea here is to construct the types for `MockWebClient` by mapping the types for Slack’s `WebClient` class. This is mainly done with the `ObjectWithMocks<Type>` type. Then the `deepCopyWithMocks<T>` function is used to implement that `ObjectWithMocks<Type>` by making a copy of an object and recursively replacing any functions with Jest mock functions. Finally, the `MockWebClientConstructor` function is used to make a class `MockWebClient` that inherits concrete versions of those new types (as applied to `WebClient`), and that acts just like `MockWebClient` does today. This part is definitely a little unusual, and hopefully the comments in the code do a good job of explaining what’s happening. The function, along with its extra type coercion, are needed because you can’t map types in a class definition, and a class can’t inherit from a type.

Alongside all that, I:
- Altered the hoisting in the workspace so the published types don’t require packages other than `jest` and `@slack/web-api` to be installed by users of this package.
- Explicitly declared a wide range of `@slack/web-api` and `jest` versions as peer dependencies. (Should these ranges have ends, like saying also `<28` for Jest? I wasn’t really sure on how conservative or open an approach would be desired here.)
- Changed the `MockedWebClient` type from `jest.MockInstance` to `jest.MockedClass`, which fixes #104 (I also added a test for this).

---

If `MockWebClient` doesn’t need to be a class, this can definitely be a little simpler to read and understand. See this commit: https://github.com/Mr0grog/slack-wrench/commit/48a09b8a82405e19d305660220797b22b7d442ff

Basically, all the stuff from the declaration of `MockWebClientConstructor` down through `MockedWebClient` could be replaced with:

```ts
export type MockWebClient = ObjectWithMocks<Slack.WebClient>;

type MockConstructor = new (
  token?: string,
  options?: Slack.WebClientOptions,
) => MockWebClient;

export const MockedWebClient: jest.MockedClass<MockConstructor> = jest.fn(
  function makeMockWebClient(this: MockWebClient) {
    const exampleClientInstance = new WebClient('MOCK_TOKEN');
    const instance = deepCopyWithMocks<Slack.WebClient>(exampleClientInstance);

    // Default for bolt apps
    // https://github.com/slackapi/bolt-js/blob/1655999346077e9521722a667414758da856ede2/src/App.ts#L579
    instance.auth.test.mockResolvedValue({
      ok: true,
      user_id: 'BOT_USER_ID',
      bot_id: 'BOT_ID',
    });

    Object.assign(this, instance);
    return this;
  },
);
```

I wasn’t sure if it would be OK for it no to be a class anymore, though. 🤷 