### PR TITLE
fix: registry publish url

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,8 +88,8 @@ jobs:
       - name: Authenticate with Registry
         run: |
           yarn logout
-          echo "@slack-wrench:registry=http://registry.npmjs.org/" > .npmrc
-          echo "registry=http://registry.npmjs.org/" >> .npmrc
+          echo "@slack-wrench:registry=https://registry.npmjs.org/" > .npmrc
+          echo "registry=https://registry.npmjs.org/" >> .npmrc
           echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> .npmrc
           npm whoami
         env:


### PR DESCRIPTION
**Related PRs**  
This PR is not dependent on any other PR

**What does this PR do?**  
Fix publish url after recent depreciation. https://github.blog/2021-08-23-npm-registry-deprecating-tls-1-0-tls-1-1/


**What gif most accurately describes how I feel towards this PR?**  

![](https://media2.giphy.com/media/4KxeicCUTvhrW/giphy.gif?cid=5a38a5a2idglakh1b33i4wlb1h2k9oyspeg4o4l5uqovkxcd&rid=giphy.gif&ct=g)