### PR TITLE
Update to allow slack/bolt 3.x

### DIFF
--- a/packages/fixtures/package.json
+++ b/packages/fixtures/package.json
@@ -20,10 +20,10 @@
     "serverless-http": "^2.3.1"
   },
   "peerDependencies": {
-    "@slack/bolt": ">=1.0.0 <3.0.0"
+    "@slack/bolt": ">=1.0.0 <4.0.0"
   },
   "devDependencies": {
-    "@slack/bolt": "^2.1.1",
+    "@slack/bolt": "^3.11.3",
     "@slack-wrench/standards": "^1.1.0"
   },
   "publishConfig": {

--- a/packages/jest-bolt-receiver/package.json
+++ b/packages/jest-bolt-receiver/package.json
@@ -15,7 +15,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@slack/bolt": "^2.1.1"
+    "@slack/bolt": "^3.11.3"
   },
   "devDependencies": {
     "@slack-wrench/fixtures": "^2.0.1",

--- a/packages/jest-mock-web-client/package.json
+++ b/packages/jest-mock-web-client/package.json
@@ -16,10 +16,10 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@slack-wrench/standards": "^1.1.0",
-    "@slack/web-api": "^5.10.0"
+    "@slack/web-api": "^6.7.2"
   },
   "peerDependencies": {
-    "@slack/web-api": ">=5.10.0",
+    "@slack/web-api": ">=6.7.2",
     "jest": ">=20"
   },
   "publishConfig": {


### PR DESCRIPTION
**Related Issue**  
Supports #131

**Related PRs**  
This PR is not dependent on any other PR

**What does this PR do?**  
This bumps the dependencies in the fixtures and jest packages to allow the latest version of bolt.

**Description of Changes**  
Bumps the version constraints in package.json to support version 3.11.3 of bolt.

**What gif most accurately describes how I feel towards this PR?**  
![Example of a gif](https://media.giphy.com/media/toe6vBrtWgKvKW7Ehz/giphy.gif)
