### PR TITLE
Update package.json

### DIFF
--- a/packages/bolt-interactions/package.json
+++ b/packages/bolt-interactions/package.json
@@ -11,7 +11,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@slack/types": "^1.6.0",
-    "@slack/web-api": "^5.6.0",
+    "@slack/web-api": "^6.11.0",
     "@types/uuid": "^8.0.1",
     "uuid": "^8.3.0"
   },


### PR DESCRIPTION
**Related Issue**  
Supports CVE-2023-45857

**What does this PR do?**  
slack/web-api major upgrade version 5.x -> 6.x to resolve axios vulnerability CVE-2023-45857

Based off of a couple quick searches through the repo, it doesn't look like upgrading slack/web-api will break any functionality: https://slack.dev/node-slack-sdk/tutorials/migrating-to-v6